### PR TITLE
bug/issue5 fix bug with "pip install edflib". Limit to numpy<2 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
-requires = ["setuptools","cython>=0.29.30,<3.0", "wheel", "numpy"]
+requires = ["setuptools","cython>=0.29.30,<3.0", "wheel", "numpy<2"]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # cython>=0.29.30,<3.0 # needed for build  # >= 0.29 #
 setuptools
 future
-numpy
+numpy<2
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ else:  # 'linux' or 'darwin'
 # ext_modules_edf = [Extension("edf", ["edf.pyx", "edflib.c"],
 #                          library_dirs=['.'],
 #                          include_dirs=include_dirs,
+#
 #                          )]
 
 ext_modules_edflib = Extension(
@@ -54,7 +55,7 @@ ext_modules_edflib = Extension(
 setup(
     name="edflib",
     version="0.84.1",
-    setup_requires=["setuptools", 'numpy'], # developmnet requires: 'cython>=0.29.30,<3.0'],
+    setup_requires=["setuptools", 'numpy<2'], # developmnet requires: 'cython>=0.29.30,<3.0'],
     install_requires=["numpy", "future"],
     description="""python edflib is a python package ot allow access to European Data Format files (EDF for short). This is a standard for biological signals such as EEG, evoked potentials and EMG.  This module wraps Teunis van Beelen's edflib.""",
     author="""Chris Lee-Messer""",


### PR DESCRIPTION
Compilation error with numpy>2. Limit to numpy<2. 
More work is needed for numpy>2.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a compilation error by restricting the numpy version to be less than 2 in the setup.py file.

- **Bug Fixes**:
    - Fixed compilation error by limiting numpy version to less than 2.

<!-- Generated by sourcery-ai[bot]: end summary -->